### PR TITLE
LM75B: Correct the mbed header referred path

### DIFF
--- a/lm75b/lm75b.h
+++ b/lm75b/lm75b.h
@@ -17,7 +17,7 @@
 #ifndef LM75B_H
 #define LM75B_H
 
-#include "mbed-drivers/mbed.h" // Building this for the mbed platform
+#include "mbed.h" // Building this for the mbed platform
 
 /** LM75B class.
  *  Used for controlling an LM75B temperature sensor connected via I2C.

--- a/source/lm75b.cpp
+++ b/source/lm75b.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "mbed-drivers/mbed.h"
-#include "minar/minar.h"
 #include "lm75b/lm75b.h"
 
 LM75B::LM75B(PinName sda, PinName scl, Address addr, int hz) : m_I2C(sda, scl), m_ADDR((int)addr)


### PR DESCRIPTION
Corrected LM75B driver to refer mbed.h header without any directory path.

### Reviewers <!-- Optional -->
@evedon, @jamesbeyond